### PR TITLE
QHTML v6: docs overhaul, module API docs, and runtime qhtmlRoot accessor rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,255 @@
-# qhtml v6.0 generation 
-> complete rebuild of entire code base to be more modern and organized as well as more capable.
-See a demo of the latest version here:
-> 
-https://qhtml.github.io/qhtml6/qhtml6/dist/demo.html
+# QHTML v6
 
+QHTML v6 is a parser + renderer + runtime system that turns QHTML source into a QDom model and then into browser DOM.
+
+Demo: https://qhtml.github.io/qhtml6/qhtml6/dist/demo.html
+
+## Language syntax reference (current supported behavior)
+
+## 1) Element blocks + attributes
+
+```qhtml
+div {
+  id: "hero"
+  data-kind: "panel"
+  p {
+    text { Hello world }
+  }
+}
+```
+
+**HTML output**
+```html
+<div id="hero" data-kind="panel"><p>Hello world</p></div>
+```
+
+## 2) Selector shorthand (class chaining supported)
+
+Class shorthand is supported:
+
+```qhtml
+div.card.primary {
+  text { Card body }
+}
+```
+
+**HTML output**
+```html
+<div class="card primary">Card body</div>
+```
+
+`#id`/full CSS selector-style parsing is **not documented as supported yet**.
+
+## 3) Multi-selector shorthand (using normal HTML tags)
+
+```qhtml
+div,section {
+  span,div {
+    text { Item }
+  }
+}
+```
+
+**HTML output**
+```html
+<div class="section"><span class="div">Item</span></div>
+```
+
+> Note: comma shorthand is legacy/class-chain friendly syntax; prefer explicit HTML tags + class attributes for clarity.
+
+## 4) Text + raw HTML blocks
+
+```qhtml
+p {
+  text { Plain text value }
+}
+
+div {
+  html { <strong>Raw HTML</strong> }
+}
+```
+
+**HTML output**
+```html
+<p>Plain text value</p>
+<div><strong>Raw HTML</strong></div>
+```
+
+`innerText { ... }` is not part of the supported syntax reference.
+
+## 5) Top-level `q-import`
+
+```qhtml
+q-import { q-components/q-modal.qhtml }
+```
+
+- Imports are recursively resolved.
+- Runtime resolves them before mount.
+
+## 6) Lifecycle blocks
+
+```qhtml
+onReady {
+  console.log("ready", this.qhtmlRoot());
+}
+
+onLoad {
+  console.log("load");
+}
+
+onLoaded {
+  console.log("loaded");
+}
+```
+
+## 7) `q-component` and `q-template`
+
+```qhtml
+q-component app-card {
+  onReady {
+    this.setAttribute("data-ready", "1");
+  }
+
+  article.card {
+    slot { default }
+  }
+}
+
+q-template field-row {
+  div.row {
+    slot { label }
+    slot { input }
+  }
+}
+```
+
+**Invocation**
+```qhtml
+app-card {
+  p { text { projected body } }
+}
+
+field-row {
+  label { text { Username } }
+  input { input { name: "username" } }
+}
+```
+
+**HTML output**
+```html
+<app-card data-ready="1"><article class="card"><p>projected body</p></article></app-card>
+<div class="row"><label>Username</label><input name="username"></div>
+```
+
+## 8) Slots
+
+```qhtml
+q-component my-layout {
+  section {
+    slot { header }
+    slot { default }
+    slot { footer }
+  }
+}
+
+my-layout {
+  header { h1 { text { Title } } }
+  p { text { Main content } }
+  footer { small { text { Footer } } }
+}
+```
+
+**HTML output**
+```html
+<my-layout><section><h1>Title</h1><p>Main content</p><small>Footer</small></section></my-layout>
+```
+
+## 9) Inline event handlers (`on<Event>`)
+
+Event handler blocks are supported directly in nodes:
+
+```qhtml
+button.primary {
+  text { Save }
+  onClick {
+    this.classList.add("clicked");
+    console.log(this.qhtmlRoot());
+  }
+  onMouseOver {
+    this.setAttribute("data-hover", "1");
+  }
+}
+```
+
+**HTML output (before events fire)**
+```html
+<button class="primary">Save</button>
+```
+
+## 10) `q-script` (source expression expansion)
+
+`q-script` can be used inline to return source fragments:
+
+```qhtml
+div q-script { return ".something" } {
+  text { Hi }
+}
+```
+
+Equivalent expanded selector shape:
+
+```qhtml
+div.something {
+  text { Hi }
+}
+```
+
+**HTML output**
+```html
+<div class="something">Hi</div>
+```
+
+---
+
+## `.qdom()` runtime API
+
+When `<q-html>` mounts:
+
+- `qHtmlElement.qdom()` → root QDom facade.
+- `renderedElement.qdom()` → mapped QDom node.
+- `renderedElement.qhtmlRoot()` → owning `<q-html>` root.
+- `renderedElement.component` → nearest component host.
+- `renderedElement.slot` → slot context when available.
+
+### QDom node helpers
+
+Available on facades:
+
+- `createQElement(options | tagName, attributes?, children?)`
+- `createQText(options | value)`
+- `createQRawHtml(options | html)`
+- `createQSlot(options | name, children?)`
+- `createQComponentInstance(options | componentId, attributes?)`
+- `createQTemplateInstance(options | componentId, attributes?)`
+- `find(selector)`
+- `findAll(selector)`
+- `findSlotFor(target)`
+- `children()` / children proxy helpers
+
+### `QDomNodeList`
+
+- `at(index)`
+- `toArray()`
+- `forEach(cb)`
+- `map(cb)`
+- `qhtml(options?)` → serialize siblings to QHTML
+- `htmldom(targetDocument?)` → `DocumentFragment`
+- `html(targetDocument?)` → HTML string
+
+## Module map
+
+- `qhtml6/modules/qdom-core` — QDom model, observation, compressed persistence
+- `qhtml6/modules/qhtml-parser` — language parser/import/rewrite/serialization
+- `qhtml6/modules/dom-renderer` — QDom → DOM rendering and slot projection
+- `qhtml6/modules/qhtml-runtime` — mount/update engine + `.qdom()` APIs
+- `qhtml6/modules/release-bundle` — release bundling script

--- a/qhtml6/dist/demo.html
+++ b/qhtml6/dist/demo.html
@@ -482,8 +482,8 @@ q-component demo-showcase {
           "    onclick {%",
           "      alert(this.tagName);",
           "      alert(this.component && this.component.tagName);",
-          "      alert(this.qhtml);",
-          "      alert(this.qhtml && this.qhtml.qdom ? this.qhtml.qdom() : \"none\");",
+          "      alert(this.qhtmlRoot && this.qhtmlRoot());",
+          "      alert(this.qhtmlRoot && this.qhtmlRoot().qdom ? this.qhtmlRoot().qdom() : \"none\");",
           "      alert(this.component && this.component.qdom ? this.component.qdom() : \"none\");",
           "      alert(this.slot && this.slot.qdom ? this.slot.qdom() : \"none\");",
           "    %}",
@@ -707,7 +707,7 @@ q-component demo-showcase {
       demo-example { id: "example-12" title: "Tiny Tabs" summary: "Implement simple tab switching behavior from scratch." }
       demo-example { id: "example-13" title: "Form Component" summary: "Handle form state and output with plain q-html methods." }
       demo-example { id: "example-14" title: "Nested Slot Forwarding" summary: "Forward outer slots through inner component layers." }
-      demo-example { id: "example-15" title: "this.component / this.qhtml / this.slot" summary: "Context pointers inside inline handlers." }
+      demo-example { id: "example-15" title: "this.component / this.qhtmlRoot() / this.slot" summary: "Context pointers inside inline handlers." }
       demo-example { id: "example-16" title: "QDom appendNode()" summary: "Programmatically append new nodes from QHTML strings." }
       demo-example { id: "example-17" title: "QDom children()" summary: "Collect child nodes and emit QHTML/HTML snapshots." }
       demo-example { id: "example-18" title: "QDom serialize()" summary: "Capture compressed source-of-truth payload for storage." }

--- a/qhtml6/modules/dom-renderer/README.md
+++ b/qhtml6/modules/dom-renderer/README.md
@@ -1,0 +1,42 @@
+# dom-renderer
+
+`dom-renderer` converts QDom into real browser DOM nodes. It is the rendering engine for both full `<q-html>` mounts and standalone component hydration.
+
+## What this module actually does
+
+- Scans a QDom document and builds a component/template registry.
+- Renders non-definition top-level nodes into a `DocumentFragment`.
+- Expands `component-instance` and `template-instance` nodes against their definitions.
+- Resolves and projects slot content (including forwarding through nested definitions).
+- Preserves association between rendered DOM nodes and source QDom nodes for runtime patching.
+- Executes lifecycle hooks after render:
+  - element-level hooks
+  - component-level hook scripts/methods
+- Emits a content-loaded signal (`QHTMLContentLoaded`) with sequencing metadata.
+
+## Rendering behaviors
+
+- `q-component` invocation renders as host custom element wrapper.
+- `q-template` invocation expands inline (no wrapper).
+- `text` nodes create text nodes; `raw-html` nodes inject parsed HTML fragments.
+- Literal `<slot>` tags are consumed as projection boundaries and removed from final DOM output.
+- Self-referential component recursion is detected and blocked.
+
+## Runtime integration points
+
+- Produces maps used by runtime (`nodeMap`, `slotMap`, component ownership, instance IDs).
+- Supports form control state synchronization hooks through stable QDom ↔ DOM mapping.
+
+## Usage example
+
+```js
+const doc = QHtmlModules.qdomCore.createDocument();
+doc.nodes.push(QHtmlModules.qdomCore.createElementNode({ tagName: "p", textContent: "Rendered" }));
+QHtmlModules.domRenderer.renderIntoElement(doc, hostElement);
+```
+
+**HTML output in `hostElement`**
+
+```html
+<p>Rendered</p>
+```

--- a/qhtml6/modules/qdom-core/MODULE-API.md
+++ b/qhtml6/modules/qdom-core/MODULE-API.md
@@ -1,85 +1,57 @@
-# MODULE API
+# MODULE API — qdom-core
 
 ## Purpose
-`qdom-core` defines the canonical QDom data model and shared runtime primitives used by parser, renderer, and browser runtime modules.
+`qdom-core` is the shared foundational module that defines QDom structures and low-level utilities used by all higher-level QHTML modules.
 
-## Boundaries
-- Owns typed QDom object shapes.
-- Owns deep observer/proxy support for reactive mutation notifications.
-- Owns compressed serialization format for persistence into `<template>` tags.
-- Does not parse QHTML text and does not render HTML DOM.
+## Export surface
+Exports via `globalThis.QHtmlModules.qdomCore`.
 
-## Public Definitions
+### Constants
 - `NODE_TYPES`
-  - String constants for QDom node kinds:
-    - `document`
-    - `element`
-    - `text`
-    - `raw-html`
-    - `component`
-    - `component-instance`
-    - `template-instance`
-    - `slot`
-    - `script-rule`
+  - `document`, `element`, `text`, `raw-html`, `component`, `component-instance`, `template-instance`, `slot`, `script-rule`.
 - `TEXT_ALIASES`
-  - Set of special text attribute aliases: `content`, `contents`, `text`, `textcontents`, `innertext`.
-- `createDocument(options)`
-  - Creates a QDom document object: `{ kind, version, nodes, scripts, meta }`.
-- `createElementNode(options)`
-  - Creates an element QDom node with `tagName`, `attributes`, `children`, `textContent`, selector metadata, and node meta.
-- `createTextNode(options)`
-  - Creates a plain text QDom node with `value`.
-- `createRawHtmlNode(options)`
-  - Creates a raw inline-html QDom node with `html`.
-- `createComponentNode(options)`
-  - Creates a q-component/q-template definition node containing:
-    - `componentId`
-    - `definitionType` (`component` or `template`)
-    - `templateNodes`
-    - optional `methods` and `lifecycleScripts`
-- `createComponentInstanceNode(options)`
-  - Creates a component/template invocation node with:
-    - `kind` (`component-instance` or `template-instance`)
-    - `componentId`
-    - host `tagName` and invocation `attributes`
-    - `slots` (list of slot nodes)
-    - fallback `children` and `textContent` for compatibility
-- `createSlotNode(options)`
-  - Creates a slot container node with:
-    - `name`
-    - `children` (QDom nodes projected into that slot)
-- `createScriptRule(options)`
-  - Creates a q-script rule node containing `selector`, `eventName`, and `body`.
-- `isNode(value)`
-  - Returns true when value matches QDom node shape.
-- `walkQDom(documentNode, visitor)`
-  - Walks all tree/script nodes with `(node, parent, path)` callback.
-- `cloneDocument(documentNode)`
-  - Deep clones an entire QDom document.
-- `ensureStringArray(value)`
-  - Normalizes to string array.
-- `mergeClasses(existing, classNames)`
-  - Merges class names into deduplicated class string.
+  - `content`, `contents`, `text`, `textcontents`, `innertext`.
+
+### Constructors
+- `createDocument(options?)`
+- `createElementNode(options?)`
+- `createTextNode(options?)`
+- `createRawHtmlNode(options?)`
+- `createComponentNode(options?)`
+- `createComponentInstanceNode(options?)`
+- `createSlotNode(options?)`
+- `createScriptRule(options?)`
+
+All constructors normalize missing fields, include `meta` objects, and produce runtime-safe defaults.
+
+### Introspection / transforms
+- `isNode(value)` — validates whether value looks like a QDom node.
+- `walkQDom(documentNode, visitor)` — traverses both tree and script collections.
+- `cloneDocument(documentNode)` — deep clone preserving document semantics.
+- `ensureStringArray(value)` — normalizes unknown value into string list.
+- `mergeClasses(existing, classNames)` — class dedupe and merge.
+
+### Reactivity
 - `observeQDom(documentNode, onChange)`
-  - Returns `{ qdom, disconnect }`; `qdom` is deep Proxy emitting immediate mutation events.
+  - Returns `{ qdom, disconnect }`.
+  - `qdom` is a deep proxy forwarding reads/writes to underlying model.
+  - Emits mutation payloads for property set/delete operations.
+
+### Persistence / serialization
 - `serializeQDomCompressed(documentNode)`
-  - Serializes full QDom document to `qdom-lzw-base64:<payload>`.
+  - Output: `qdom-lzw-base64:<payload>`.
 - `deserializeQDomCompressed(payload)`
-  - Rehydrates serialized QDom payload back into object form.
 - `saveQDomTemplateBefore(qHtmlElement, documentNode, doc?)`
-  - Writes serialized payload into exactly one mapped `<template data-qdom="1" data-qdom-for="...">` immediately before `<q-html>`.
+  - Writes/updates mapped persisted template before `<q-html>`.
 - `loadQDomTemplateBefore(qHtmlElement)`
-  - Reads and deserializes persisted QDom payload from adjacent/mapped template.
+  - Loads persisted template payload (or `null`).
 
-## Side Effects and External Dependencies
-- Uses browser global primitives where available (`TextEncoder`, `TextDecoder`, `btoa`, `atob`, `document`).
-- Falls back to Node `Buffer` for base64 in non-browser test contexts.
+## Behavioral notes
+- Compression stack: JSON → binary string → LZW codes → varint bytes → base64.
+- Base64 supports browser globals (`btoa`/`atob`) and Node fallback (`Buffer`).
+- Persistence mapping uses host identity (`data-qdom-host`) and cleanup of duplicates.
+- Mutation observation marks touched objects and root document as dirty.
 
-## Cross-Module Imports/Exports
-- Exports API on `globalThis.QHtmlModules.qdomCore`.
-- Consumed by `qhtml-parser`, `dom-renderer`, and `qhtml-runtime`.
-
-## Backward Compatibility Notes
-- Initial v1 API.
-- Serialized payload prefix is versioned (`qdom-lzw-base64`) to allow future format migration.
-- Template persistence enforces a strict 1:1 mapping between each `<q-html>` and a single serialized QDom template, even when hosts move between parent containers.
+## Module dependencies
+- No internal dependency on parser/renderer/runtime.
+- Uses host globals when present (`document`, encoding/base64 utilities).

--- a/qhtml6/modules/qdom-core/README.md
+++ b/qhtml6/modules/qdom-core/README.md
@@ -1,0 +1,62 @@
+# qdom-core
+
+`qdom-core` is the canonical data-model module for QHTML v6. It defines QDom node shapes, constructors, traversal helpers, deep observation, and compressed persistence utilities used by parser/runtime/renderer.
+
+## What this module actually does
+
+- Defines every runtime node type used across the system (`document`, `element`, `text`, `raw-html`, `component`, `component-instance`, `template-instance`, `slot`, `script-rule`).
+- Provides factory constructors for all QDom node kinds with normalized defaults and metadata.
+- Implements deep tree walking (`walkQDom`) and deep cloning (`cloneDocument`) so other modules can inspect and transform QDom safely.
+- Implements mutation observation through deep `Proxy` wrapping (`observeQDom`) and reports precise mutation envelopes (`set`, `delete`, path, old/new values).
+- Marks mutated nodes/documents as dirty for round-trip serializer behavior.
+- Implements compact persistence of QDom using LZW + varint + base64 (`qdom-lzw-base64:<payload>`).
+- Saves/loads serialized QDom into sibling `<template data-qdom="1">` tags adjacent to `<q-html>` hosts.
+
+## Why other modules depend on it
+
+- `qhtml-parser` uses constructors and node constants when turning source text into QDom.
+- `dom-renderer` relies on normalized node kinds and structures when mapping QDom to actual DOM.
+- `qhtml-runtime` relies on observation + template persistence to keep rendered DOM and source model synchronized.
+
+## Data model summary
+
+- Document shape: `{ kind, version, nodes, scripts, meta }`
+- Element shape: `{ kind, tagName, attributes, children, textContent, selectorMode, selectorChain, meta }`
+- Component/template definition shape: `{ kind: "component", componentId, definitionType, templateNodes, methods, lifecycleScripts, meta }`
+- Component/template invocation shape: `{ kind: "component-instance" | "template-instance", componentId, tagName, attributes, slots, children, textContent, ... }`
+- Slot shape: `{ kind: "slot", name, children, ... }`
+- Script rule shape: `{ kind: "script-rule", selector, eventName, body, meta }`
+
+## Persistence behavior
+
+- Serialized payloads are written before `<q-html>` as mapped `<template data-qdom="1" data-qdom-for="...">` nodes.
+- Duplicate persisted templates for the same host mapping are cleaned up.
+- Loading prefers mapped templates and gracefully returns `null` when no valid payload exists.
+
+## Observation behavior
+
+- `observeQDom(documentNode, onChange)` returns `{ qdom, disconnect }`.
+- `qdom` is a deep proxy that preserves original object identities via cache.
+- Writes and deletes trigger:
+  - `meta.dirty = true` on target + root document.
+  - callback mutation object with full path.
+- Calling `disconnect()` disables callback emissions while leaving proxy usable.
+
+## Usage example
+
+```js
+const doc = QHtmlModules.qdomCore.createDocument();
+doc.nodes.push(
+  QHtmlModules.qdomCore.createElementNode({
+    tagName: "div",
+    attributes: { class: "box" },
+    textContent: "Hello",
+  })
+);
+```
+
+**Rendered HTML result (after renderer/runtime consume this QDom):**
+
+```html
+<div class="box">Hello</div>
+```

--- a/qhtml6/modules/qhtml-parser/MODULE-API.md
+++ b/qhtml6/modules/qhtml-parser/MODULE-API.md
@@ -1,63 +1,47 @@
-# MODULE API
+# MODULE API — qhtml-parser
 
 ## Purpose
-`qhtml-parser` converts QHTML source text into AST/QDom structures and serializes QDom back into QHTML source.
+Transforms QHTML text into QDom and back, with import resolution and preprocessing support.
 
-## Boundaries
-- Owns QHTML grammar parsing logic.
-- Owns selector-mode interpretation and legacy selector token normalization.
-- Owns q-script rule parsing/serialization.
-- Does not render DOM nodes or perform runtime DOM scanning.
+## Export surface
+Exports via `globalThis.QHtmlModules.qhtmlParser`.
 
-## Public Definitions
-- `KNOWN_HTML_TAGS`
-  - Set of built-in tags used for selector interpretation.
+### Constants
+- `KNOWN_HTML_TAGS` — tag allowlist/recognition set used during parsing decisions.
+
+### Core parse APIs
 - `parseQHtmlToAst(source)`
-  - Parses QHTML source into an AST.
-  - Supports legacy forms used by previous qhtml.js editions:
-    - `tag.class1.class2 { ... }`
-    - `text { ... }`, `style { ... }`, `on* { ... }`
-    - top-level lifecycle blocks: `onReady { ... }`, `onLoad { ... }`, `onLoaded { ... }`
-    - component method blocks: `function methodName(args) { ... }`
-    - selector-prefix directives: `tag.slot { slot-key } { ... }`
-    - `q-template template-id { ... }`
-    - `q-component component-id { ... }`
-    - `slot { slot-name }` shorthand
+  - Produces intermediate AST for diagnostics/tooling.
 - `parseQHtmlToQDom(source, options?)`
-  - Converts QHTML source into `qdom-core` document structure.
-  - Models `text { ... }` content as explicit QText child nodes, preserving source order with sibling nodes like `html { ... }`, elements, and slots.
-  - Supports pre-parse recursive import expansion via `options.loadImportSync` and `options.importBaseUrl`.
-  - Resolves component/template invocations into explicit QDom instance nodes:
-    - `component-instance`
-    - `template-instance`
-    - named `slot` containers (with text captured as `text` nodes when available)
-  - Preserves slot-forwarding directives inside instance slot containers so nested template/component projection can be resolved at render time.
+  - Produces QDom document.
+  - Key options:
+    - `resolveImportsBeforeParse` (default true)
+    - `loadImportSync(url)` for sync import expansion
+    - `importBaseUrl`, `maxImports`, `importCache`
+    - `maxQRewritePasses`, `maxQScriptPasses`
+    - `scriptRules` preparsed q-script rules
+
+### Preprocessing/import APIs
+- `applyQRewriteBlocks(source, options?)`
+  - Expands `q-rewrite` macros with slot substitution or script-generated output.
 - `resolveQImportsSync(source, options?)`
-  - Recursively resolves `q-import { ... }` blocks before AST conversion.
-  - Resolves nested relative imports against the current/base URL.
-  - Guards against circular imports and excessive import depth via `maxImports`.
 - `resolveQImportsAsync(source, options?)`
-  - Async equivalent of recursive import resolution using async loaders (for runtime `fetch()` import loading).
+  - Both recursively inline `q-import` blocks.
+  - Detect circular imports and enforce max import count.
+
+### Serialization APIs
 - `qdomToQHtml(documentNode, options?)`
-  - Serializes QDom back to QHTML; preserves original source when document is unmodified.
-  - Serializes explicit QText/RawHtml child nodes in-order, so mixed content round-trips losslessly.
-  - Preserves definition kind on dirty serialization:
-    - `q-template ... { ... }` remains template syntax
-    - `q-component ... { ... }` remains component syntax
-  - Emits lifecycle blocks from both element scope and top-level document scope when serializing dirty QDom.
+  - Converts QDom document to canonical QHTML source.
+  - `preserveOriginal` defaults to true.
 - `parseQScript(source)`
-  - Parses q-script event definitions into typed `script-rule` objects.
+  - Parses q-script rules of form `selector.on("event"): { ... }`.
 - `serializeQScript(rules)`
-  - Converts script rules back to q-script source text.
+  - Serializes script rules back to source.
 
-## Side Effects and External Dependencies
-- Depends on `globalThis.QHtmlModules.qdomCore`.
-- Throws parse errors (`QHtmlParseError`) on malformed source.
+## Error model
+- Throws `QHtmlParseError` with `.index` for syntax errors.
+- Import/macro stages throw descriptive `Error` messages for recursion/limits/unbalanced blocks.
 
-## Cross-Module Imports/Exports
-- Imports `qdom-core` constructors/utilities.
-- Exports API on `globalThis.QHtmlModules.qhtmlParser`.
-- Used by `qhtml-runtime` and tooling.
-
-## Backward Compatibility Notes
-- Legacy syntax acceptance is expanded to minimize breakage for existing qhtml.js pages while retaining QDom as the source of truth.
+## Cross-module usage
+- Requires `qdom-core` for node creation and type constants.
+- Consumed by `qhtml-runtime` for mount-time parsing and source export workflows.

--- a/qhtml6/modules/qhtml-parser/README.md
+++ b/qhtml6/modules/qhtml-parser/README.md
@@ -1,0 +1,61 @@
+# qhtml-parser
+
+`qhtml-parser` is the language layer for QHTML v6. It parses QHTML source into QDom, applies macro/script preprocessing, resolves imports, and serializes QDom back to source.
+
+## What this module actually does
+
+- Parses QHTML into an AST and then into typed QDom nodes.
+- Supports component and template definitions (`q-component`, `q-template`) and converts element invocations into `component-instance` / `template-instance` nodes when definitions are known.
+- Parses top-level lifecycle blocks (`onReady`, `onLoad`, `onLoaded`) and stores them in document metadata.
+- Parses `on<Event>` inline event blocks into script-bearing element attributes.
+- Resolves recursive `q-import { ... }` chains (sync or async), including circular import protection and max-depth guards.
+- Supports `q-rewrite` macro-like expansion before parse.
+- Supports q-script evaluation passes for source preprocessing.
+- Serializes QDom back to QHTML, preserving original source when model is clean.
+
+## Parsing model
+
+1. Optional import resolution (`resolveQImportsSync/Async`).
+2. `q-rewrite` expansion passes.
+3. q-script evaluation passes.
+4. AST parse.
+5. AST → QDom conversion.
+6. Definition-aware normalization (component/template invocation shaping, slots).
+
+## Language constructs handled here
+
+- Structural blocks: selectors `{ ... }`
+- Attribute assignment: `name: "value"`
+- Text blocks: `text { ... }`, `innertext { ... }`, and aliases
+- Raw HTML blocks: `html { ... }`
+- Style blocks mapped into `<style>` nodes
+- Function blocks inside component/template definitions
+- Lifecycle hook blocks (document and component/element scope)
+- Slot declarations and slot fills
+- q-import blocks
+- q-rewrite definitions + invocations
+
+`q-script` in this module is treated as source-time expansion support (script returns source fragments that become part of QHTML before final parse).
+
+## Usage example
+
+```qhtml
+div.notice {
+  text { Hello }
+  onClick {
+    this.classList.add("clicked");
+  }
+}
+```
+
+**HTML output**
+
+```html
+<div class="notice">Hello</div>
+```
+
+## Serializer behavior
+
+- Uses original source when `meta.dirty` is false and `preserveOriginal` is enabled.
+- Emits explicit QDom shapes when dirty (including slots, invocation nodes, lifecycle scripts).
+- Preserves definition kind: template stays `q-template`, component stays `q-component`.

--- a/qhtml6/modules/qhtml-runtime/README.md
+++ b/qhtml6/modules/qhtml-runtime/README.md
@@ -1,0 +1,67 @@
+# qhtml-runtime
+
+`qhtml-runtime` is the browser orchestration layer. It mounts `<q-html>` blocks, keeps QDom observed, applies incremental updates, wires inline event handlers, and exposes the `.qdom()` developer API.
+
+## What this module actually does
+
+- Auto-discovers and mounts `<q-html>` elements on load (and optionally as they are inserted later).
+- Loads QDom from persisted sibling template when available, otherwise parses inline source.
+- Resolves `q-import` asynchronously before parse during mount.
+- Observes QDom mutations and applies:
+  - in-place DOM patches for non-structural changes
+  - full render replacement for structural changes
+- Persists updated QDom back into mapped `<template data-qdom="1">` storage.
+- Wires inline `on<Event>` handlers to rendered DOM nodes.
+- Registers valid `q-component` definitions as custom elements.
+- Hydrates component host elements and maintains component/slot context accessors in rendered DOM.
+
+## `.qdom()` model in runtime
+
+- `qHtmlElement.qdom()` returns proxied document facade with node factories and query helpers.
+- Each mapped rendered element receives `.qdom()` that returns the associated source QDom node.
+- Convenience aliases:
+  - `element.qhtmlRoot()` returns the owning `<q-html>` host.
+  - `element.component` points to nearest component instance host.
+  - `element.slot` exposes slot context where applicable.
+
+## QDom facade capabilities
+
+The installed node facade includes:
+
+- Creation helpers:
+  - `createQElement(...)`
+  - `createQText(...)`
+  - `createQRawHtml(...)`
+  - `createQSlot(...)`
+  - `createQComponentInstance(...)`
+  - `createQTemplateInstance(...)`
+- Query helpers:
+  - `find(selector)`
+  - `findAll(selector)`
+  - `findSlotFor(target)`
+  - `slots()`
+- Child access:
+  - `children()` returns `QDomNodeList`
+  - proxy-style child operations via `children.push/unshift/splice`, index access, `length`
+
+`QDomNodeList` supports `at`, `toArray`, `forEach`, `map`, `qhtml`, `htmldom`, and `html`.
+
+## Usage example
+
+```qhtml
+<q-html>
+button.cta {
+  text { Save }
+  onClick {
+    const root = this.qhtmlRoot();
+    root.setAttribute("data-last-click", "save");
+  }
+}
+</q-html>
+```
+
+**Rendered HTML (before click):**
+
+```html
+<button class="cta">Save</button>
+```

--- a/qhtml6/modules/qhtml-runtime/src/qhtml-runtime.js
+++ b/qhtml6/modules/qhtml-runtime/src/qhtml-runtime.js
@@ -2459,7 +2459,9 @@
     host.qdom = function hostQdomAccessor() {
       return installQDomFactories(binding.qdom);
     };
-    host.qhtml = host;
+    host.qhtmlRoot = function hostQhtmlRootAccessor() {
+      return host;
+    };
     host.component = null;
 
     function setSlotContextAccessor(element, slotNode, dynamicResolver) {
@@ -2693,7 +2695,9 @@
           return installQDomFactories(sourceNode);
         };
       }
-      element.qhtml = host;
+      element.qhtmlRoot = function elementQhtmlRootAccessor() {
+        return host;
+      };
 
       const componentHost = binding.componentMap && binding.componentMap.get(element);
       setComponentContextAccessor(element, componentHost || resolveNearestComponentHost(element) || null);

--- a/qhtml6/modules/release-bundle/MODULE-API.md
+++ b/qhtml6/modules/release-bundle/MODULE-API.md
@@ -1,27 +1,28 @@
-# MODULE API
+# MODULE API — release-bundle
 
 ## Purpose
-`release-bundle` produces the distributable browser artifact by combining all module scripts into a single dependency-ordered file.
+Generate the distributable single-file QHTML runtime bundle.
 
-## Boundaries
-- Owns release assembly mechanics only.
-- Does not implement parser/runtime/renderer logic.
-
-## Public Definitions
+## Entrypoint
 - `build-release.sh`
-  - Command script that generates `dist/qhtml.js` from module source files in dependency order.
 
-## Side Effects and External Dependencies
-- Creates/overwrites `dist/qhtml.js` in project root.
-- Requires source module files plus root integration file to exist.
+## Behavior
+- Computes project paths relative to script location.
+- Ensures output directory exists (`dist/`).
+- Validates presence of all required module sources.
+- Concatenates sources in dependency order with `BEGIN/END` markers.
+- Writes output to `dist/qhtml.js`.
 
-## Cross-Module Imports/Exports
-- Reads outputs from:
-  - `modules/qdom-core/src/qdom-core.js`
-  - `modules/qhtml-parser/src/qhtml-parser.js`
-  - `modules/dom-renderer/src/dom-renderer.js`
-  - `modules/qhtml-runtime/src/qhtml-runtime.js`
-  - `src/root-integration.js`
+## Inputs
+- `modules/qdom-core/src/qdom-core.js`
+- `modules/qhtml-parser/src/qhtml-parser.js`
+- `modules/dom-renderer/src/dom-renderer.js`
+- `modules/qhtml-runtime/src/qhtml-runtime.js`
+- `src/root-integration.js`
 
-## Backward Compatibility Notes
-- Initial build format is concatenated IIFE-compatible script.
+## Outputs
+- `dist/qhtml.js`
+
+## Exit behavior
+- Non-zero exit on missing input source.
+- Zero on successful bundle creation.

--- a/qhtml6/modules/release-bundle/README.md
+++ b/qhtml6/modules/release-bundle/README.md
@@ -1,0 +1,32 @@
+# release-bundle
+
+`release-bundle` is the packaging module for producing the browser-distributed `dist/qhtml.js` artifact.
+
+## What this module actually does
+
+- Defines strict module concatenation order so global module dependencies attach correctly:
+  1. `qdom-core`
+  2. `qhtml-parser`
+  3. `dom-renderer`
+  4. `qhtml-runtime`
+  5. `src/root-integration.js`
+- Verifies required source files exist before building.
+- Writes a generated header with UTC timestamp.
+- Produces a single bundle file at `qhtml6/dist/qhtml.js`.
+
+## Why this module matters
+
+- Runtime modules are loaded as IIFE globals, so ordering is required.
+- Central build script keeps distribution predictable and reproducible.
+
+## Usage example
+
+```bash
+bash modules/release-bundle/build-release.sh
+```
+
+**Output result**
+
+```text
+Wrote /workspace/qhtml6/qhtml6/dist/qhtml.js
+```


### PR DESCRIPTION
### Motivation

- Consolidate and document the QHTML v6 design, language syntax, module responsibilities, and runtime APIs. 
- Make DOM/runtime accessors clearer and more explicit by replacing ambiguous `qhtml` accessors with `qhtmlRoot()` to reflect root ownership. 
- Provide module-level documentation for `qdom-core`, `qhtml-parser`, `dom-renderer`, `qhtml-runtime`, and `release-bundle` to improve discoverability and maintenance. 

### Description

- Rewrote top-level `README.md` to a comprehensive QHTML v6 syntax and runtime reference and updated the demo link. 
- Added `MODULE-API.md` and `README.md` for `qdom-core`, `qhtml-parser`, `dom-renderer`, `qhtml-runtime`, and `release-bundle`, plus module README files under `qhtml6/modules/*`. 
- Updated `qhtml6/dist/demo.html` snippets and demo metadata to use `this.qhtmlRoot()` and changed example title/summary to reflect the new accessor name. 
- Modified runtime code in `qhtml6/modules/qhtml-runtime/src/qhtml-runtime.js` to expose `host.qhtmlRoot` and `element.qhtmlRoot` accessors (replacing `host.qhtml`/`element.qhtml`) and ensure mapped elements return the new accessor; preserved existing `qdom`/component/slot facades. 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a20fea61108320814e957d3cc51774)